### PR TITLE
Bug fix: Fetch the most recent obsv, not the last

### DIFF
--- a/pyipma/location.py
+++ b/pyipma/location.py
@@ -126,8 +126,8 @@ class Location:
             try:
                 LOGGER.debug("Get Observation for %s", station.idEstacao)
                 observations = await obs.get(station.idEstacao)
-                if len(observations) and observations[0] is not None:
-                    return observations[0]
+                if len(observations) and observations[-1] is not None:
+                    return observations[-1]
             except Exception as err:
                 LOGGER.warning(
                     "Could not retrieve obsertation for %s: %s", station, err

--- a/tests/test_location.py
+++ b/tests/test_location.py
@@ -38,8 +38,9 @@ async def test_location():
                 payload=json.load(open("fixtures/observations.json")),
             )
             obs = await location.observation(api)
-            assert obs.temperature == 17.7
-            assert obs.humidity == 88.0
+            assert obs.timestamp == datetime(2022, 7, 28, 23,0)
+            assert obs.temperature == 18.7
+            assert obs.humidity == 91.0
 
             # 1010500 is the globalIdLocal for Aveiro
             assert location.global_id_local == 1010500


### PR DESCRIPTION
I've fixed a bug where the API was always retrieving the first Observation instead of the first one. IPMA API sends a list of 24 observations (one Observation for each hour of the current day). The old code was sorting this list in chronological order and picking the first Observation instead of the most recent one. The fix is very simple and minimalistic, I just changed the index from 0 to -1 so that the last item of the list is selected.

I also corrected the respective test and added a new asset to ensure the API is selected the Observation with the expected timestamp.

This bug affecting all users of the Home Assistant IPMA integration (where I detected the issue). The integration is showing the weather with almost a day of delay.